### PR TITLE
Pin snscrape to importlib-compatible commit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 streamlit
 pandas
 duckduckgo-search
-snscrape
+snscrape @ git+https://github.com/JustAnotherArchivist/snscrape.git@614d4c2029a62d348ca56598f87c425966aaec66
 instaloader
 google-api-python-client


### PR DESCRIPTION
## Summary
- Pin `snscrape` to commit 614d4c2029a62d348ca56598f87c425966aaec66 to ensure modern importlib support

## Testing
- `pip install -r requirements.txt`
- `streamlit run app/onebar.py`


------
https://chatgpt.com/codex/tasks/task_e_68aaf3390f0c8324824d2d3bf9f3e75e