### PR TITLE
Use ddgs for handle detection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 streamlit
 pandas
-duckduckgo-search
+ddgs
 snscrape @ git+https://github.com/JustAnotherArchivist/snscrape.git@6fb98dae1240b3264afa9d3337be5be0f836622d
 instaloader
 google-api-python-client

--- a/utils/handles.py
+++ b/utils/handles.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, Optional
 
-from duckduckgo_search import DDGS
+from ddgs import DDGS
 
 
 PLATFORM_PATTERNS = {


### PR DESCRIPTION
## Summary
- replace deprecated duckduckgo_search with ddgs for handle detection
- update requirements to use ddgs instead of duckduckgo-search

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `python - <<'PY'
from functools import partial
import utils.handles as handles
handles.DDGS = partial(handles.DDGS, verify=False)
print(handles.detect_handles('Taylor Swift', ['twitter']))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ab077f4bd48324b444f5e1476017b3