### PR TITLE
Harden collectors against scrape failures

### DIFF
--- a/app/onebar.py
+++ b/app/onebar.py
@@ -2,13 +2,9 @@
 from __future__ import annotations
 
 import streamlit as st
-import pandas as pd
 
 from utils.handles import detect_handles
-from collectors.twitter import collect_twitter
-from collectors.instagram import collect_instagram
-from collectors.youtube import collect_youtube
-from processing.merger import merge_posts
+from collectors import collect_all
 from analysis.audit import generate_audit
 from utils.io import save_raw, save_master, save_report
 
@@ -27,30 +23,18 @@ if st.button("Search & Analyze") and name:
     handles = detect_handles(name)
     st.write("Detected handles:", handles)
 
-    dfs = []
-    if handle := handles.get("twitter"):
-        df = collect_twitter(handle, months)
-        if not df.empty:
-            save_raw(df, "twitter", handle)
-            dfs.append(df)
-    if handle := handles.get("instagram"):
-        df = collect_instagram(handle, months)
-        if not df.empty:
-            save_raw(df, "instagram", handle)
-            dfs.append(df)
-    if yt_key and (handle := handles.get("youtube")):
-        df = collect_youtube(handle, yt_key, months)
-        if not df.empty:
-            save_raw(df, "youtube", handle)
-            dfs.append(df)
-
-    master = merge_posts(dfs)
+    master = collect_all(handles, months, yt_key)
     if not master.empty:
+        for platform, df in master.groupby("platform"):
+            handle = handles.get(platform, "")
+            save_raw(df, platform, handle)
         save_master(master)
         report = generate_audit(master, name)
         save_report(report, name)
         st.markdown(report)
-        st.download_button("Download report", report, file_name=f"{name}_audit.md")
+        st.download_button(
+            "Download report", report, file_name=f"{name}_audit.md"
+        )
     else:
         st.warning("No data collected.")
 

--- a/collectors/__init__.py
+++ b/collectors/__init__.py
@@ -1,0 +1,55 @@
+"""Unified social-media collectors."""
+from __future__ import annotations
+
+from typing import Dict, Optional, List
+
+import logging
+import pandas as pd
+
+from .twitter import collect_twitter, SCHEMA
+from .instagram import collect_instagram
+from .youtube import collect_youtube
+
+__all__ = [
+    "collect_twitter",
+    "collect_instagram",
+    "collect_youtube",
+    "collect_all",
+    "SCHEMA",
+]
+
+
+def collect_all(
+    handles: Dict[str, str], months: int = 6, yt_key: Optional[str] = None
+) -> pd.DataFrame:
+    """Collect posts for available handles across supported platforms."""
+    dfs: List[pd.DataFrame] = []
+    logger = logging.getLogger(__name__)
+
+    if handle := handles.get("twitter"):
+        try:
+            df = collect_twitter(handle, months)
+            if not df.empty:
+                dfs.append(df)
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.warning("Twitter collection failed: %s", exc)
+
+    if handle := handles.get("instagram"):
+        try:
+            df = collect_instagram(handle, months)
+            if not df.empty:
+                dfs.append(df)
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.warning("Instagram collection failed: %s", exc)
+
+    if yt_key and (handle := handles.get("youtube")):
+        try:
+            df = collect_youtube(handle, yt_key, months)
+            if not df.empty:
+                dfs.append(df)
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.warning("YouTube collection failed: %s", exc)
+
+    if dfs:
+        return pd.concat(dfs, ignore_index=True)
+    return pd.DataFrame(columns=SCHEMA)

--- a/collectors/instagram.py
+++ b/collectors/instagram.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+import logging
+import os
 
 import pandas as pd
 import instaloader
@@ -9,12 +11,25 @@ import instaloader
 from .twitter import SCHEMA  # reuse schema
 
 
+logger = logging.getLogger(__name__)
+
 loader = instaloader.Instaloader(
     quiet=True,
     download_geotags=False,
     download_comments=False,
     save_metadata=False,
+    user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0 Safari/537.36",
 )
+
+# Optional login to improve reliability on protected endpoints
+_IG_USER = os.getenv("INSTAGRAM_USER")
+_IG_PASS = os.getenv("INSTAGRAM_PASS")
+if _IG_USER and _IG_PASS:  # pragma: no cover - requires credentials
+    try:
+        loader.login(_IG_USER, _IG_PASS)
+    except instaloader.exceptions.InstaloaderException as exc:
+        logger.warning("Instagram login failed: %s", exc)
 
 
 def collect_instagram(handle: str, months: int = 6) -> pd.DataFrame:
@@ -46,8 +61,8 @@ def collect_instagram(handle: str, months: int = 6) -> pd.DataFrame:
                     "is_competitor": False,
                 }
             )
-    except Exception:
-        pass
+    except instaloader.exceptions.InstaloaderException as exc:
+        logger.warning("Instagram scrape failed: %s", exc)
     df = pd.DataFrame(posts, columns=SCHEMA)
     return df
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 streamlit
 pandas
-duckduckgo-search
+ddgs
 snscrape @ git+https://github.com/JustAnotherArchivist/snscrape.git@6fb98dae1240b3264afa9d3337be5be0f836622d
 instaloader
 google-api-python-client

--- a/src/collect/collect_instagram.py
+++ b/src/collect/collect_instagram.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+import logging
 
 import pandas as pd
 import instaloader
@@ -9,11 +10,15 @@ import instaloader
 from .twitter import SCHEMA  # reuse schema
 
 
+logger = logging.getLogger(__name__)
+
 loader = instaloader.Instaloader(
     quiet=True,
     download_geotags=False,
     download_comments=False,
     save_metadata=False,
+    user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0 Safari/537.36",
 )
 
 
@@ -46,8 +51,8 @@ def collect_instagram(handle: str, months: int = 6) -> pd.DataFrame:
                     "is_competitor": False,
                 }
             )
-    except Exception:
-        pass
+    except instaloader.exceptions.InstaloaderException as exc:
+        logger.warning("Instagram scrape failed: %s", exc)
     df = pd.DataFrame(posts, columns=SCHEMA)
     return df
 

--- a/utils/handles.py
+++ b/utils/handles.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, Optional
 
-from duckduckgo_search import DDGS
+from ddgs import DDGS
 
 
 PLATFORM_PATTERNS = {


### PR DESCRIPTION
## Summary
- guard collect_all against individual platform failures
- allow Instagram login via environment variables to cut down on 4xx errors

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `python - <<'PY'\nimport logging\nfrom collectors import collect_all\nhandles={'twitter':'jack','instagram':'instagram'}\nprint('collecting...')\ndf = collect_all(handles, months=1)\nprint(df.head())\nprint('rows', len(df))\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68ab077f4bd48324b444f5e1476017b3